### PR TITLE
7 shadow dom events

### DIFF
--- a/8-web-components/7-shadow-dom-events/article.md
+++ b/8-web-components/7-shadow-dom-events/article.md
@@ -1,0 +1,192 @@
+# Shadow DOM and events
+
+The idea behind shadow tree is to encapsulate internal implementation details of a component.
+
+Let's say, a click event happens inside a shadow DOM of `<user-card>` component. But scripts in the main document have no idea about the shadow DOM internals, especially if the component comes from a 3rd-party library.  
+
+So, to keep the details encapsulated, the browser *retargets* the event.
+
+**Events that happen in shadow DOM have the host element as the target, when caught outside of the component.**
+
+Here's a simple example:
+
+```html run autorun="no-epub" untrusted height=60
+<user-card></user-card>
+
+<script>
+customElements.define('user-card', class extends HTMLElement {
+  connectedCallback() {
+    this.attachShadow({mode: 'open'});
+    this.shadowRoot.innerHTML = `<p>
+      <button>Click me</button>
+    </p>`;
+    this.shadowRoot.firstElementChild.onclick =
+      e => alert("Inner target: " + e.target.tagName);
+  }
+});
+
+document.onclick =
+  e => alert("Outer target: " + e.target.tagName);
+</script>
+```
+
+If you click on the button, the messages are:
+
+1. Inner target: `BUTTON` -- internal event handler gets the correct target, the element inside shadow DOM.
+2. Outer target: `USER-CARD` -- document event handler gets shadow host as the target.
+
+Event retargeting is a great thing to have, because the outer document doesn't have to know  about component internals. From its point of view, the event happened on `<user-card>`.
+
+**Retargeting does not occur if the event occurs on a slotted element, that physically lives in the light DOM.**
+
+For example, if a user clicks on `<span slot="username">` in the example below, the event target is exactly this `span` element, for both shadow and light handlers:
+
+```html run autorun="no-epub" untrusted height=60
+<user-card id="userCard">
+*!*
+  <span slot="username">John Smith</span>
+*/!*
+</user-card>
+
+<script>
+customElements.define('user-card', class extends HTMLElement {
+  connectedCallback() {
+    this.attachShadow({mode: 'open'});
+    this.shadowRoot.innerHTML = `<div>
+      <b>Name:</b> <slot name="username"></slot>
+    </div>`;
+
+    this.shadowRoot.firstElementChild.onclick =
+      e => alert("Inner target: " + e.target.tagName);
+  }
+});
+
+userCard.onclick = e => alert(`Outer target: ${e.target.tagName}`);
+</script>
+```
+
+If a click happens on `"John Smith"`, for both inner and outer handlers the target is `<span slot="username">`. That's an element from the light DOM, so no retargeting.
+
+On the other hand, if the click occurs on an element originating from shadow DOM, e.g. on `<b>Name</b>`, then, as it bubbles out of the shadow DOM, its `event.target` is reset to `<user-card>`.
+
+## Bubbling, event.composedPath()
+
+For purposes of event bubbling, flattened DOM is used.
+
+So, if we have a slotted element, and an event occurs somewhere inside it, then it bubbles up to the `<slot>` and upwards.
+
+The full path to the original event target, with all the shadow elements, can be obtained using `event.composedPath()`. As we can see from the name of the method, that path is taken after the composition.
+
+In the example above, the flattened DOM is:
+
+```html
+<user-card id="userCard">
+  #shadow-root
+    <div>
+      <b>Name:</b>
+      <slot name="username">
+        <span slot="username">John Smith</span>
+      </slot>
+    </div>
+</user-card>
+```
+
+
+So, for a click on `<span slot="username">`, a call to `event.composedPath()` returns an array: [`span`, `slot`, `div`, `shadow-root`, `user-card`, `body`, `html`, `document`, `window`]. That's exactly the parent chain from the target element in the flattened DOM, after the composition.
+
+```warn header="Shadow tree details are only provided for `{mode:'open'}` trees"
+If the shadow tree was created with `{mode: 'closed'}`, then the composed path starts from the host: `user-card` and upwards.
+
+That's the similar principle as for other methods that work with shadow DOM. Internals of closed trees are completely hidden.
+```
+
+
+## event.composed
+
+Most events successfully bubble through a shadow DOM boundary. There are few events that do not.
+
+This is governed by the `composed` event object property. If it's `true`, then the event does cross the boundary. Otherwise, it only can be caught from inside the shadow DOM.
+
+If you take a look at [UI Events specification](https://www.w3.org/TR/uievents), most events have `composed: true`:
+
+- `blur`, `focus`, `focusin`, `focusout`,
+- `click`, `dblclick`,
+- `mousedown`, `mouseup` `mousemove`, `mouseout`, `mouseover`,
+- `wheel`,
+- `beforeinput`, `input`, `keydown`, `keyup`.
+
+All touch events and pointer events also have `composed: true`.
+
+There are some events that have `composed: false` though:
+
+- `mouseenter`, `mouseleave` (they do not bubble at all),
+- `load`, `unload`, `abort`, `error`,
+- `select`,
+- `slotchange`.
+
+These events can be caught only on elements within the same DOM, where the event target resides.
+
+## Custom events
+
+When we dispatch custom events, we need to set both `bubbles` and `composed` properties to `true` for it to bubble up and out of the component.
+
+For example, here we create `div#inner` in the shadow DOM of `div#outer` and trigger two events on it. Only the one with `composed: true` makes it outside to the document:
+
+```html run untrusted height=0
+<div id="outer"></div>
+
+<script>
+outer.attachShadow({mode: 'open'});
+
+let inner = document.createElement('div');
+outer.shadowRoot.append(inner);
+
+/*
+div(id=outer)
+  #shadow-dom
+    div(id=inner)
+*/
+
+document.addEventListener('test', event => alert(event.detail));
+
+inner.dispatchEvent(new CustomEvent('test', {
+  bubbles: true,
+*!*
+  composed: true,
+*/!*
+  detail: "composed"
+}));
+
+inner.dispatchEvent(new CustomEvent('test', {
+  bubbles: true,
+*!*
+  composed: false,
+*/!*
+  detail: "not composed"
+}));
+</script>
+```
+
+## Summary
+
+Events only cross shadow DOM boundaries if their `composed` flag is set to `true`.
+
+Built-in events mostly have `composed: true`, as described in the relevant specifications:
+
+- UI Events <https://www.w3.org/TR/uievents>.
+- Touch Events <https://w3c.github.io/touch-events>.
+- Pointer Events <https://www.w3.org/TR/pointerevents>.
+- ...And so on.
+
+Some built-in events that have `composed: false`:
+
+- `mouseenter`, `mouseleave` (also do not bubble),
+- `load`, `unload`, `abort`, `error`,
+- `select`,
+- `slotchange`.
+
+These events can be caught only on elements within the same DOM.
+
+If we dispatch a `CustomEvent`, then we should explicitly set `composed: true`.
+
+Please note that in case of nested components, one shadow DOM may be nested into another. In that case composed events bubble through all shadow DOM boundaries. So, if an event is intended only for the immediate enclosing component, we can also dispatch it on the shadow host and set `composed: false`. Then it's out of the component shadow DOM, but won't bubble up to higher-level DOM.

--- a/8-web-components/7-shadow-dom-events/article.md
+++ b/8-web-components/7-shadow-dom-events/article.md
@@ -4,6 +4,7 @@ shadow ツリーの背後にあるアイデアは、コンポーネント内部�
 例えば、クリックイベントがshadow DOMの`<user-card>`コンポーネント内で発生したとします。しかしメインドキュメント内のスクリプトはshadow DOM内部については何も知りません。特にコンポーネントがサードパーティライブラリから来たものである場合はなおさらです。
 
 なので、詳細をカプセル化したままにするために、ブラウザはイベントを*リターゲティングします。*
+
 **shadow DOM内で発生するイベントがコンポーネントの外でキャッチされると、そのイベントはターゲットとしてShadowホスト要素を持ちます。**
 
 ```html run autorun="no-epub" untrusted height=60
@@ -28,9 +29,12 @@ document.onclick =
 
 ボタンをクリックした場合、そのメッセージは:
 1. 内部ターゲット: `BUTTON` -- 内部イベントハンドラーは適切なターゲット、shadow DOM内の要素を取得します。
+
 2. 外部ターゲット: `USER-CARD` -- ドキュメントイベントハンドラーはターゲットとしてShadow ホストを取得します。
+
 イベントリターゲティングは、外部ドキュメントがコンポーネントの内部について知らなくてもいいので、素晴らしいものです。この観点から、イベントは`<user-card>`に起こります。
-**リターゲティングは、イベントが物理的にlight DOM内に存在するスロットされた要素上で起こった場合には、発生しません。**
+
+**リターゲティングは、物理的にlight DOM内に存在するスロット化された要素上でイベントが起こった場合には発生しません。**
 例えば、ユーザーが以下の例の`<span slot="username">`をクリックした場合、shadowハンドラー とlightハンドラーの両方で、イベントターゲットはまさにこの`span`要素になります。
 ```html run autorun="no-epub" untrusted height=60
 <user-card id="userCard">
@@ -57,7 +61,7 @@ userCard.onclick = e => alert(`Outer target: ${e.target.tagName}`);
 ```
 
 クリックが`"John Smith"`で起こった場合は、内部と外部のハンドラーのターゲットは`<span slot="username">`になります。それはlight DOMからの要素なので、リターゲティングはありません。
-その一方で、クリックが`<b>Name</b>`のようなshadow DOMに由来する要素で発生した場合、shadow DOMの外にバブルするように、その`event.target`は`<user-card>`にセットし直されます。
+その一方で、クリックが`<b>Name</b>`のようなshadow shadow DOMの外にバブルするので、その`event.target`は`<user-card>`にセットし直されます。
 
 ## バブリング、 event.composedPath()
 イベントバブリングでは、フラット化されたDOMが使用されます。
@@ -90,8 +94,8 @@ Shadow ツリーが`{mode: 'closed'}`で作られた場合、その合成パス�
 
 ほとんどのイベントはshadow DOMの境界を通してバブルします。しかしイベントの中にはこのルールに従わないものもあります。
 
-これは`composed`イベントオブジェクトプロパティによって管理されます。`true`の場合は、イベントは境界を超えます。そうでない場合は、shadow DOM内からのみ取得します。
-[UI Events specification](https://www.w3.org/TR/uievents)をご覧いただくと、ほとんどのイベントは`composed: true`です。：
+これは`composed`イベントオブジェクトプロパティによって管理されます。`true`の場合は、イベントは境界を超えます。そうでない場合は、shadow DOM内からのみ取得できます。
+[UI Events 使用](https://www.w3.org/TR/uievents)をご覧いただくと、ほとんどのイベントは`composed: true`です。：
 
 - `blur`, `focus`, `focusin`, `focusout`,
 - `click`, `dblclick`,
@@ -152,8 +156,8 @@ inner.dispatchEvent(new CustomEvent('test', {
 
 ## サマリ
 
-`composed`フラグが`true`に設定されている場合、イベントはshadow DOM境界のみを超えます。
-組み込みのイベントは、関連する仕様に記載されている通り、ほとんどの場合`composed: true`を持ちます:
+`composed`フラグが`true`に設定されている場合にのみ、イベントはshadow DOM境界を超えます。
+組み込みのイベントは、関連する仕様に記載されている通り、ほとんどの場合`composed: true`です:
 - UIイベント <https://www.w3.org/TR/uievents>.
 - タッチイベント <https://w3c.github.io/touch-events>.
 - ポインターイベント <https://www.w3.org/TR/pointerevents>.
@@ -166,8 +170,8 @@ inner.dispatchEvent(new CustomEvent('test', {
 - `select`,
 - `slotchange`.
 
-これらのイベントは同じDOM内の要素でのみキャッチされます。
+これらのイベントは同じDOM内の要素でのみキャッチできます。
 
 `CustomEvent`をディスパッチする場合は、明確に`composed: true`を設定するべきです。
 
-ネストされているコンポーネントの場合は、一つのshadow DOMは互いにネストされてないことに気をつけてください。その場合は、合成されたイベントは全てのshadow DOM境界を通してバブルします。なので、イベントが直近の囲まれているコンポーネントのみを目的として作成されている場合は、`composed: false`を設定してShadow ホストをディスパッチすることができます。そしてshadow DOMのコンポーネントに外れますが、高次元DOMへはバブルしないでしょう。
+ネストされたコンポーネント、ある shadow DOM が別の shadow DOM にネストされる場合があることに注意してください。この場合、合成されたイベントはすべての shadow DOM 境界をバブルします。したがって、もしイベントが直接囲んでいるコンポーネントだけを意図している場合は、そのイベントを shadow ホストにディスパッチして、`composed: false` にすることもできます。すると、イベントはコンポーネントのシャドウDOMの外にありますが、上位レベルのDOMにバブルアップすることはありません。

--- a/8-web-components/7-shadow-dom-events/article.md
+++ b/8-web-components/7-shadow-dom-events/article.md
@@ -109,10 +109,12 @@ That's the similar principle as for other methods that work with shadow DOM. Int
 ## event.composed
 
 Most events successfully bubble through a shadow DOM boundary. There are few events that do not.
+ほとんどのイベントはshadow DOMの境界を通して浮上します。しかしいくつかのイベントはこのルールに従わないものもあります。
 
 This is governed by the `composed` event object property. If it's `true`, then the event does cross the boundary. Otherwise, it only can be caught from inside the shadow DOM.
-
+これは`composed`イベントオブジェクトプロパティによって管理されます。`true`の場合は、イベントは境界を超えます。そうでない場合は、shadow DOM内からのみ取得します。
 If you take a look at [UI Events specification](https://www.w3.org/TR/uievents), most events have `composed: true`:
+[UI Events specification](https://www.w3.org/TR/uievents)をご覧いただくと、ほとんどのイベントは`composed: true`：
 
 - `blur`, `focus`, `focusin`, `focusout`,
 - `click`, `dblclick`,
@@ -121,15 +123,18 @@ If you take a look at [UI Events specification](https://www.w3.org/TR/uievents),
 - `beforeinput`, `input`, `keydown`, `keyup`.
 
 All touch events and pointer events also have `composed: true`.
+全てのタッチイベントとポインターは、`composed: true`です。
 
 There are some events that have `composed: false` though:
-
+いくつかのイベントは`composed: false`ですが：
 - `mouseenter`, `mouseleave` (they do not bubble at all),
+- `mouseenter`, `mouseleave` (これらは全く浮上しません),
 - `load`, `unload`, `abort`, `error`,
 - `select`,
 - `slotchange`.
 
 These events can be caught only on elements within the same DOM, where the event target resides.
+これらのイベントはイベントターゲットが属する同じDOM内の要素でのみキャッチされます。
 
 ## Custom events
 

--- a/8-web-components/7-shadow-dom-events/article.md
+++ b/8-web-components/7-shadow-dom-events/article.md
@@ -1,15 +1,10 @@
-# Shadow DOM and events
 # Shadow DOMとイベント
-The idea behind shadow tree is to encapsulate internal implementation details of a component.
-shadow ツリーの背後にあるアイデアは、内部のコンポーネントの実装の詳細をカプセル化させることにあります。
+shadow ツリーの背後にあるアイデアは、コンポーネント内部の実装の詳細をカプセル化することにあります。
 
-Let's say, a click event happens inside a shadow DOM of `<user-card>` component. But scripts in the main document have no idea about the shadow DOM internals, especially if the component comes from a 3rd-party library.  
-例えば、クリックイベントがshadow DOMの`<user-card>`コンポーネント内で発生したとします。しかしメインドキュメント内のスクリプトはshadow DOM内部については何も知りません。特にもしコンポーネントがサードパーティライブラリから来たものであればなおさらです。
+例えば、クリックイベントがshadow DOMの`<user-card>`コンポーネント内で発生したとします。しかしメインドキュメント内のスクリプトはshadow DOM内部については何も知りません。特にコンポーネントがサードパーティライブラリから来たものである場合はなおさらです。
 
-So, to keep the details encapsulated, the browser *retargets* the event.
-詳細をカプセル化したままにするために、ブラウザはイベントを*リターゲティングします。*
-**Events that happen in shadow DOM have the host element as the target, when caught outside of the component.**
-**shadow DOM内で起こるイベントはコンポーネントの外で取得される時、ターゲットとしてそのホスト要素を持ちます。**
+なので、詳細をカプセル化したままにするために、ブラウザはイベントを*リターゲティングします。*
+**shadow DOM内で起こるイベントがコンポーネントの外で取得される時、そのイベントはターゲットとしてホスト要素を持ちます。**
 
 ```html run autorun="no-epub" untrusted height=60
 <user-card></user-card>
@@ -31,18 +26,12 @@ document.onclick =
 </script>
 ```
 
-If you click on the button, the messages are:
-ボタンをクリックした場合、メッセージは
-1. Inner target: `BUTTON` -- internal event handler gets the correct target, the element inside shadow DOM.
-1. 内部ターゲット: `BUTTON` -- 内部イベントハンドラーはshadow DOM内の要素を適切なターゲットを取得します。
-2. Outer target: `USER-CARD` -- document event handler gets shadow host as the target.
+ボタンをクリックした場合、そのメッセージは:
+1. 内部ターゲット: `BUTTON` -- 内部イベントハンドラーは適切なターゲット、shadow DOM内の要素を取得します。
 2. 外部ターゲット: `USER-CARD` -- ドキュメントイベントハンドラーはターゲットとしてShadow ホストを取得します。
-Event retargeting is a great thing to have, because the outer document doesn't have to know  about component internals. From its point of view, the event happened on `<user-card>`.
 イベントリターゲティングは、外部ドキュメントがコンポーネントの内部について知らなくてもいいので、素晴らしいものです。この観点から、イベントは`<user-card>`に起こります。
-**Retargeting does not occur if the event occurs on a slotted element, that physically lives in the light DOM.**
-**リターゲティングは、イベントが物理的にlightDOM内に存在するスロットされた要素上で起こった場合には発生しません。**
-For example, if a user clicks on `<span slot="username">` in the example below, the event target is exactly this `span` element, for both shadow and light handlers:
-例えば、ユーザーが以下の例の`<span slot="username">`をクリックした場合、シャドウハンドラーとライトハンドラーの両方で、イベントターゲットはまさにこの`span`要素になります。
+**リターゲティングは、イベントが物理的にlight DOM内に存在するスロットされた要素上で起こった場合には、発生しません。**
+例えば、ユーザーが以下の例の`<span slot="username">`をクリックした場合、shadowハンドラー とlightハンドラーの両方で、イベントターゲットはまさにこの`span`要素になります。
 ```html run autorun="no-epub" untrusted height=60
 <user-card id="userCard">
 *!*
@@ -67,20 +56,14 @@ userCard.onclick = e => alert(`Outer target: ${e.target.tagName}`);
 </script>
 ```
 
-If a click happens on `"John Smith"`, for both inner and outer handlers the target is `<span slot="username">`. That's an element from the light DOM, so no retargeting.
 クリックが`"John Smith"`で起こった場合は、内部と外部のハンドラーのターゲットは`<span slot="username">`になります。それはlight DOMからの要素なので、リターゲティングはありません。
-On the other hand, if the click occurs on an element originating from shadow DOM, e.g. on `<b>Name</b>`, then, as it bubbles out of the shadow DOM, its `event.target` is reset to `<user-card>`.
-一方で、クリックがshadow DOMに由来する要素で発生した場合、例えば`<b>Name</b>`上の場合、それから、shadow DOMの外にバブルするように、その`event.target`は`<user-card>`にリセットします。
-## Bubbling, event.composedPath()
-## バブリング、 event.composedPath()
-For purposes of event bubbling, flattened DOM is used.
-イベントバブリングの目的に、フラット化したDOMが使用されます。
-So, if we have a slotted element, and an event occurs somewhere inside it, then it bubbles up to the `<slot>` and upwards.
-なので、スロット化された要素があり、イベントがその内部のどこかで起こった場合は、`<slot>`よりも上部に浮上します。
-The full path to the original event target, with all the shadow elements, can be obtained using `event.composedPath()`. As we can see from the name of the method, that path is taken after the composition.
-全てのシャドウ要素と共に、オリジナルのイベントターゲットへのフルパスは、`event.composedPath()`を使用して取得されます。このメソッドの名前から分かる通り、そのパスは合成後に取得されます。
+その一方で、クリックが`<b>Name</b>`のようなshadow DOMに由来する要素で発生した場合、shadow DOMの外にバブルするように、その`event.target`は`<user-card>`にリセットされます。
 
-In the example above, the flattened DOM is:
+## バブリング、 event.composedPath()
+イベントバブリングの目的に、フラット化したDOMが使用されます。
+なので、スロット化された要素があり、イベントがその内部のどこかで起こった場合は、そのイベントは`<slot>`よりも上部に浮上します。
+全てのshadow要素と共に、オリジナルのイベントターゲットへの絶対パスは、`event.composedPath()`を使用して取得されます。このメソッドの名前から分かる通り、そのパスは合成後に取得されます。
+
 上記の例では、フラット化されたDOMは:
 ```html
 <user-card id="userCard">
@@ -95,26 +78,20 @@ In the example above, the flattened DOM is:
 ```
 
 
-So, for a click on `<span slot="username">`, a call to `event.composedPath()` returns an array: [`span`, `slot`, `div`, `shadow-root`, `user-card`, `body`, `html`, `document`, `window`]. That's exactly the parent chain from the target element in the flattened DOM, after the composition.
 なので、`<span slot="username">`のクリックで、`event.composedPath()`のコールは配列[`span`, `slot`, `div`, `shadow-root`, `user-card`, `body`, `html`, `document`, `window`]を返します。これがまさに合成後のフラット化DOM内でのターゲット要素から親チェーンのことです。
 
 ```warn header="Shadow tree details are only provided for `{mode:'open'}` trees"
-If the shadow tree was created with `{mode: 'closed'}`, then the composed path starts from the host: `user-card` and upwards.
 Shadow ツリーが`{mode: 'closed'}`と作られた場合、その合成パスはホスト: `user-card`とその上部から始まります。
-That's the similar principle as for other methods that work with shadow DOM. Internals of closed trees are completely hidden.
-これはshadow DOMと作用する他のメソッドと同様の原理です。閉じた木の内部は完全に隠されています。
+これはshadow DOMと作用する他のメソッドと同様の原理です。閉じた木の内部は完璧に隠されています。
 ```
 
 
 ## event.composed
 
-Most events successfully bubble through a shadow DOM boundary. There are few events that do not.
-ほとんどのイベントはshadow DOMの境界を通して浮上します。しかしいくつかのイベントはこのルールに従わないものもあります。
+ほとんどのイベントはshadow DOMの境界を通してバブルします。しかしイベントの中にはこのルールに従わないものもあります。
 
-This is governed by the `composed` event object property. If it's `true`, then the event does cross the boundary. Otherwise, it only can be caught from inside the shadow DOM.
 これは`composed`イベントオブジェクトプロパティによって管理されます。`true`の場合は、イベントは境界を超えます。そうでない場合は、shadow DOM内からのみ取得します。
-If you take a look at [UI Events specification](https://www.w3.org/TR/uievents), most events have `composed: true`:
-[UI Events specification](https://www.w3.org/TR/uievents)をご覧いただくと、ほとんどのイベントは`composed: true`：
+[UI Events specification](https://www.w3.org/TR/uievents)をご覧いただくと、ほとんどのイベントは`composed: true`です。：
 
 - `blur`, `focus`, `focusin`, `focusout`,
 - `click`, `dblclick`,
@@ -122,28 +99,21 @@ If you take a look at [UI Events specification](https://www.w3.org/TR/uievents),
 - `wheel`,
 - `beforeinput`, `input`, `keydown`, `keyup`.
 
-All touch events and pointer events also have `composed: true`.
 全てのタッチイベントとポインターは、`composed: true`です。
 
-There are some events that have `composed: false` though:
-いくつかのイベントは`composed: false`ですが：
-- `mouseenter`, `mouseleave` (they do not bubble at all),
-- `mouseenter`, `mouseleave` (これらは全く浮上しません),
+イベントの中には`composed: false`のものもありますが：
+- `mouseenter`, `mouseleave` (これらは全くバブルしません),
 - `load`, `unload`, `abort`, `error`,
 - `select`,
 - `slotchange`.
 
-These events can be caught only on elements within the same DOM, where the event target resides.
 これらのイベントはイベントターゲットが属する同じDOM内の要素でのみキャッチされます。
 
-## Custom events
 ## カスタムイベント
 
-When we dispatch custom events, we need to set both `bubbles` and `composed` properties to `true` for it to bubble up and out of the component.
 カスタムイベントをディスパッチすると、コンポーネントの外に浮上させるために`bubbles`と`composed`の両方のプロパティを`true`に設定する必要があります。
 
-For example, here we create `div#inner` in the shadow DOM of `div#outer` and trigger two events on it. Only the one with `composed: true` makes it outside to the document:
-例えば、`div#inner`をshadow DOMの`div#outer`に作成し、二つのイベントを発火します。`composed: true`をもつイベントのみがドキュメントの外に浮上します。
+例えば、`div#inner`をshadow DOMの`div#outer`に作成し、二つのイベントを発火します。`composed: true`をもつイベントのみがドキュメントの外に浮上します。:
 
 ```html run untrusted height=0
 <div id="outer"></div>
@@ -180,33 +150,24 @@ inner.dispatchEvent(new CustomEvent('test', {
 </script>
 ```
 
-## Summary
+## サマリ
 
-Events only cross shadow DOM boundaries if their `composed` flag is set to `true`.
 `composed`フラグが`true`に設定されている場合、イベントはshadow DOM境界のみをクロスします。
-Built-in events mostly have `composed: true`, as described in the relevant specifications:
-ビルトインイベントは、関連する仕様に記載されている通り、ほとんどの場合`composed: true`を持ちます:
-- UI Events <https://www.w3.org/TR/uievents>.
+組み込みのイベントは、関連する仕様に記載されている通り、ほとんどの場合`composed: true`を持ちます:
 - UIイベント <https://www.w3.org/TR/uievents>.
-- Touch Events <https://w3c.github.io/touch-events>.
 - タッチイベント <https://w3c.github.io/touch-events>.
 - ポインターイベント <https://www.w3.org/TR/pointerevents>.
 - ...など.
 
-Some built-in events that have `composed: false`:
-いくつかのビルトインイベントは`composed: false`を持ちます:
+組み込みイベントの中には`composed: false`を持ちます:
 
-- `mouseenter`, `mouseleave` (also do not bubble),
 - `mouseenter`, `mouseleave` (バブルしません),
 - `load`, `unload`, `abort`, `error`,
 - `select`,
 - `slotchange`.
 
-These events can be caught only on elements within the same DOM.
 これらのイベントは同じDOM内の要素でのみキャッチされます。
 
-If we dispatch a `CustomEvent`, then we should explicitly set `composed: true`.
 `CustomEvent`をディスパッチする場合は、明確に`composed: true`を設定するべきです。
 
-Please note that in case of nested components, one shadow DOM may be nested into another. In that case composed events bubble through all shadow DOM boundaries. So, if an event is intended only for the immediate enclosing component, we can also dispatch it on the shadow host and set `composed: false`. Then it's out of the component shadow DOM, but won't bubble up to higher-level DOM.
-ネストされているコンポーネントの場合は、一つのshadow DOMは互いにネストされてないことに気をつけてください。その場合は、合成されたイベントは全てのshadow DOM境界を通して浮上します。なので、イベントが直近の囲まれているコンポーネントのみを目的として作成されている場合は、`composed: false`を設定してshadow hostをディスパッチすることができます。そしてshadow DOMのコンポーネントに外れますが、高次元DOMへは浮上しないでしょう。
+ネストされているコンポーネントの場合は、一つのshadow DOMは互いにネストされてないことに気をつけてください。その場合は、合成されたイベントは全てのshadow DOM境界を通して浮上します。なので、イベントが直近の囲まれているコンポーネントのみを目的として作成されている場合は、`composed: false`を設定してShadow ホストをディスパッチすることができます。そしてshadow DOMのコンポーネントに外れますが、高次元DOMへは浮上しないでしょう。

--- a/8-web-components/7-shadow-dom-events/article.md
+++ b/8-web-components/7-shadow-dom-events/article.md
@@ -183,23 +183,30 @@ inner.dispatchEvent(new CustomEvent('test', {
 ## Summary
 
 Events only cross shadow DOM boundaries if their `composed` flag is set to `true`.
-
+`composed`フラグが`true`に設定されている場合、イベントはshadow DOM境界のみをクロスします。
 Built-in events mostly have `composed: true`, as described in the relevant specifications:
-
+ビルトインイベントは、関連する仕様に記載されている通り、ほとんどの場合`composed: true`を持ちます:
 - UI Events <https://www.w3.org/TR/uievents>.
+- UIイベント <https://www.w3.org/TR/uievents>.
 - Touch Events <https://w3c.github.io/touch-events>.
-- Pointer Events <https://www.w3.org/TR/pointerevents>.
-- ...And so on.
+- タッチイベント <https://w3c.github.io/touch-events>.
+- ポインターイベント <https://www.w3.org/TR/pointerevents>.
+- ...など.
 
 Some built-in events that have `composed: false`:
+いくつかのビルトインイベントは`composed: false`を持ちます:
 
 - `mouseenter`, `mouseleave` (also do not bubble),
+- `mouseenter`, `mouseleave` (バブルしません),
 - `load`, `unload`, `abort`, `error`,
 - `select`,
 - `slotchange`.
 
 These events can be caught only on elements within the same DOM.
+これらのイベントは同じDOM内の要素でのみキャッチされます。
 
 If we dispatch a `CustomEvent`, then we should explicitly set `composed: true`.
+`CustomEvent`をディスパッチする場合は、明確に`composed: true`を設定するべきです。
 
 Please note that in case of nested components, one shadow DOM may be nested into another. In that case composed events bubble through all shadow DOM boundaries. So, if an event is intended only for the immediate enclosing component, we can also dispatch it on the shadow host and set `composed: false`. Then it's out of the component shadow DOM, but won't bubble up to higher-level DOM.
+ネストされているコンポーネントの場合は、一つのshadow DOMは互いにネストされてないことに気をつけてください。その場合は、合成されたイベントは全てのshadow DOM境界を通して浮上します。なので、イベントが直近の囲まれているコンポーネントのみを目的として作成されている場合は、`composed: false`を設定してshadow hostをディスパッチすることができます。そしてshadow DOMのコンポーネントに外れますが、高次元DOMへは浮上しないでしょう。

--- a/8-web-components/7-shadow-dom-events/article.md
+++ b/8-web-components/7-shadow-dom-events/article.md
@@ -4,7 +4,7 @@ shadow ツリーの背後にあるアイデアは、コンポーネント内部�
 例えば、クリックイベントがshadow DOMの`<user-card>`コンポーネント内で発生したとします。しかしメインドキュメント内のスクリプトはshadow DOM内部については何も知りません。特にコンポーネントがサードパーティライブラリから来たものである場合はなおさらです。
 
 なので、詳細をカプセル化したままにするために、ブラウザはイベントを*リターゲティングします。*
-**shadow DOM内で起こるイベントがコンポーネントの外で取得される時、そのイベントはターゲットとしてホスト要素を持ちます。**
+**shadow DOM内で発生するイベントがコンポーネントの外でキャッチされると、そのイベントはターゲットとしてShadowホスト要素を持ちます。**
 
 ```html run autorun="no-epub" untrusted height=60
 <user-card></user-card>
@@ -57,12 +57,12 @@ userCard.onclick = e => alert(`Outer target: ${e.target.tagName}`);
 ```
 
 クリックが`"John Smith"`で起こった場合は、内部と外部のハンドラーのターゲットは`<span slot="username">`になります。それはlight DOMからの要素なので、リターゲティングはありません。
-その一方で、クリックが`<b>Name</b>`のようなshadow DOMに由来する要素で発生した場合、shadow DOMの外にバブルするように、その`event.target`は`<user-card>`にリセットされます。
+その一方で、クリックが`<b>Name</b>`のようなshadow DOMに由来する要素で発生した場合、shadow DOMの外にバブルするように、その`event.target`は`<user-card>`にセットし直されます。
 
 ## バブリング、 event.composedPath()
-イベントバブリングの目的に、フラット化したDOMが使用されます。
-なので、スロット化された要素があり、イベントがその内部のどこかで起こった場合は、そのイベントは`<slot>`よりも上部に浮上します。
-全てのshadow要素と共に、オリジナルのイベントターゲットへの絶対パスは、`event.composedPath()`を使用して取得されます。このメソッドの名前から分かる通り、そのパスは合成後に取得されます。
+イベントバブリングでは、フラット化されたDOMが使用されます。
+したがって、スロット化された要素が存在し、その中のどこかでイベントが発生した場合、そのイベントは`<slot>`まで上方にバブリングします。
+全てのshadow要素を含む、オリジナルのイベントターゲットへの絶対パスは、`event.composedPath()`を使用して取得できます。このメソッドの名前から分かる通り、そのパスは合成後に取得されます。
 
 上記の例では、フラット化されたDOMは:
 ```html
@@ -78,11 +78,11 @@ userCard.onclick = e => alert(`Outer target: ${e.target.tagName}`);
 ```
 
 
-なので、`<span slot="username">`のクリックで、`event.composedPath()`のコールは配列[`span`, `slot`, `div`, `shadow-root`, `user-card`, `body`, `html`, `document`, `window`]を返します。これがまさに合成後のフラット化DOM内でのターゲット要素から親チェーンのことです。
+なので、`<span slot="username">`のクリックで、`event.composedPath()`の呼び出しは配列[`span`, `slot`, `div`, `shadow-root`, `user-card`, `body`, `html`, `document`, `window`]を返します。これがまさに合成後のフラット化されたDOM内でのターゲット要素から親へのチェーンのことです。
 
-```warn header="Shadow tree details are only provided for `{mode:'open'}` trees"
-Shadow ツリーが`{mode: 'closed'}`と作られた場合、その合成パスはホスト: `user-card`とその上部から始まります。
-これはshadow DOMと作用する他のメソッドと同様の原理です。閉じた木の内部は完璧に隠されています。
+```warn header="Shadow ツリーの詳細は `{mode:'open'}` ツリーにのみ提供されます"
+Shadow ツリーが`{mode: 'closed'}`で作られた場合、その合成パスはホスト: `user-card`とその上部から始まります。
+これはshadow DOMと作用する他のメソッドと同様の原理です。閉じたツリーの内部は完璧に隠されています。
 ```
 
 
@@ -111,9 +111,9 @@ Shadow ツリーが`{mode: 'closed'}`と作られた場合、その合成パス�
 
 ## カスタムイベント
 
-カスタムイベントをディスパッチすると、コンポーネントの外に浮上させるために`bubbles`と`composed`の両方のプロパティを`true`に設定する必要があります。
+カスタムイベントをディスパッチすると、コンポーネントの外にバブルさせるために`bubbles`と`composed`の両方のプロパティを`true`に設定する必要があります。
 
-例えば、`div#inner`をshadow DOMの`div#outer`に作成し、二つのイベントを発火します。`composed: true`をもつイベントのみがドキュメントの外に浮上します。:
+例えば、ここでは`div#outer`のshadow DOMに`div#inner`を作成し、二つのイベントを発火します。`composed: true`をもつイベントのみがドキュメントの外にバブルします。:
 
 ```html run untrusted height=0
 <div id="outer"></div>
@@ -152,14 +152,14 @@ inner.dispatchEvent(new CustomEvent('test', {
 
 ## サマリ
 
-`composed`フラグが`true`に設定されている場合、イベントはshadow DOM境界のみをクロスします。
+`composed`フラグが`true`に設定されている場合、イベントはshadow DOM境界のみを超えます。
 組み込みのイベントは、関連する仕様に記載されている通り、ほとんどの場合`composed: true`を持ちます:
 - UIイベント <https://www.w3.org/TR/uievents>.
 - タッチイベント <https://w3c.github.io/touch-events>.
 - ポインターイベント <https://www.w3.org/TR/pointerevents>.
 - ...など.
 
-組み込みイベントの中には`composed: false`を持ちます:
+組み込みイベントの中には`composed: false`のものもあります:
 
 - `mouseenter`, `mouseleave` (バブルしません),
 - `load`, `unload`, `abort`, `error`,
@@ -170,4 +170,4 @@ inner.dispatchEvent(new CustomEvent('test', {
 
 `CustomEvent`をディスパッチする場合は、明確に`composed: true`を設定するべきです。
 
-ネストされているコンポーネントの場合は、一つのshadow DOMは互いにネストされてないことに気をつけてください。その場合は、合成されたイベントは全てのshadow DOM境界を通して浮上します。なので、イベントが直近の囲まれているコンポーネントのみを目的として作成されている場合は、`composed: false`を設定してShadow ホストをディスパッチすることができます。そしてshadow DOMのコンポーネントに外れますが、高次元DOMへは浮上しないでしょう。
+ネストされているコンポーネントの場合は、一つのshadow DOMは互いにネストされてないことに気をつけてください。その場合は、合成されたイベントは全てのshadow DOM境界を通してバブルします。なので、イベントが直近の囲まれているコンポーネントのみを目的として作成されている場合は、`composed: false`を設定してShadow ホストをディスパッチすることができます。そしてshadow DOMのコンポーネントに外れますが、高次元DOMへはバブルしないでしょう。

--- a/8-web-components/7-shadow-dom-events/article.md
+++ b/8-web-components/7-shadow-dom-events/article.md
@@ -137,10 +137,13 @@ These events can be caught only on elements within the same DOM, where the event
 これらのイベントはイベントターゲットが属する同じDOM内の要素でのみキャッチされます。
 
 ## Custom events
+## カスタムイベント
 
 When we dispatch custom events, we need to set both `bubbles` and `composed` properties to `true` for it to bubble up and out of the component.
+カスタムイベントをディスパッチすると、コンポーネントの外に浮上させるために`bubbles`と`composed`の両方のプロパティを`true`に設定する必要があります。
 
 For example, here we create `div#inner` in the shadow DOM of `div#outer` and trigger two events on it. Only the one with `composed: true` makes it outside to the document:
+例えば、`div#inner`をshadow DOMの`div#outer`に作成し、二つのイベントを発火します。`composed: true`をもつイベントのみがドキュメントの外に浮上します。
 
 ```html run untrusted height=0
 <div id="outer"></div>

--- a/8-web-components/7-shadow-dom-events/article.md
+++ b/8-web-components/7-shadow-dom-events/article.md
@@ -1,14 +1,15 @@
 # Shadow DOM and events
 
 The idea behind shadow tree is to encapsulate internal implementation details of a component.
+shadow ツリーの背後にあるアイデアは、内部のコンポーネントの実装の詳細をカプセル化させることにあります。
 
 Let's say, a click event happens inside a shadow DOM of `<user-card>` component. But scripts in the main document have no idea about the shadow DOM internals, especially if the component comes from a 3rd-party library.  
+例えば、クリックイベントがshadow DOMの`<user-card>`コンポーネント内で発生したとします。しかしメインドキュメント内のスクリプトはshadow DOM内部については何も知りません。特にもしコンポーネントがサードパーティライブラリから来たものであればなおさらです。
 
 So, to keep the details encapsulated, the browser *retargets* the event.
-
+詳細をカプセル化したままにするために、ブラウザはイベントを*リターゲティングします。*
 **Events that happen in shadow DOM have the host element as the target, when caught outside of the component.**
-
-Here's a simple example:
+**shadow DOM内で起こるイベントはコンポーネントの外で取得される時、ターゲットとしてそのホスト要素を持ちます。**
 
 ```html run autorun="no-epub" untrusted height=60
 <user-card></user-card>
@@ -31,16 +32,17 @@ document.onclick =
 ```
 
 If you click on the button, the messages are:
-
+ボタンをクリックした場合、メッセージは
 1. Inner target: `BUTTON` -- internal event handler gets the correct target, the element inside shadow DOM.
+1. 内部ターゲット: `BUTTON` -- 内部イベントハンドラーはshadow DOM内の要素を適切なターゲットを取得します。
 2. Outer target: `USER-CARD` -- document event handler gets shadow host as the target.
-
+2. 外部ターゲット: `USER-CARD` -- ドキュメントイベントハンドラーはターゲットとしてShadow ホストを取得します。
 Event retargeting is a great thing to have, because the outer document doesn't have to know  about component internals. From its point of view, the event happened on `<user-card>`.
-
+イベントリターゲティングは、外部ドキュメントがコンポーネントの内部について知らなくてもいいので、素晴らしいものです。この観点から、イベントは`<user-card>`に起こります。
 **Retargeting does not occur if the event occurs on a slotted element, that physically lives in the light DOM.**
-
+**リターゲティングは、イベントが物理的にlightDOM内に存在するスロットされた要素上で起こった場合には発生しません。**
 For example, if a user clicks on `<span slot="username">` in the example below, the event target is exactly this `span` element, for both shadow and light handlers:
-
+例えば、ユーザーが以下の例の`<span slot="username">`をクリックした場合、シャドウハンドラーとライトハンドラーの両方で、イベントターゲットはまさにこの`span`要素になります。
 ```html run autorun="no-epub" untrusted height=60
 <user-card id="userCard">
 *!*
@@ -66,9 +68,9 @@ userCard.onclick = e => alert(`Outer target: ${e.target.tagName}`);
 ```
 
 If a click happens on `"John Smith"`, for both inner and outer handlers the target is `<span slot="username">`. That's an element from the light DOM, so no retargeting.
-
+クリックが`"John Smith"`で起こった場合は、内部と外部のハンドラーのターゲットは`<span slot="username">`になります。それはlight DOMからの要素なので、リターゲティングはありません。
 On the other hand, if the click occurs on an element originating from shadow DOM, e.g. on `<b>Name</b>`, then, as it bubbles out of the shadow DOM, its `event.target` is reset to `<user-card>`.
-
+一方で、クリックがshadow DOMに由来する要素で発生した場合、例えば`<b>Name</b>`上の場合、それから、shadow DOMの外にバブルするように、その`event.target`は`<user-card>`にリセットします。
 ## Bubbling, event.composedPath()
 
 For purposes of event bubbling, flattened DOM is used.

--- a/8-web-components/7-shadow-dom-events/article.md
+++ b/8-web-components/7-shadow-dom-events/article.md
@@ -1,5 +1,5 @@
 # Shadow DOM and events
-
+# Shadow DOMとイベント
 The idea behind shadow tree is to encapsulate internal implementation details of a component.
 shadow ツリーの背後にあるアイデアは、内部のコンポーネントの実装の詳細をカプセル化させることにあります。
 
@@ -72,15 +72,16 @@ If a click happens on `"John Smith"`, for both inner and outer handlers the targ
 On the other hand, if the click occurs on an element originating from shadow DOM, e.g. on `<b>Name</b>`, then, as it bubbles out of the shadow DOM, its `event.target` is reset to `<user-card>`.
 一方で、クリックがshadow DOMに由来する要素で発生した場合、例えば`<b>Name</b>`上の場合、それから、shadow DOMの外にバブルするように、その`event.target`は`<user-card>`にリセットします。
 ## Bubbling, event.composedPath()
-
+## バブリング、 event.composedPath()
 For purposes of event bubbling, flattened DOM is used.
-
+イベントバブリングの目的に、フラット化したDOMが使用されます。
 So, if we have a slotted element, and an event occurs somewhere inside it, then it bubbles up to the `<slot>` and upwards.
-
+なので、スロット化された要素があり、イベントがその内部のどこかで起こった場合は、`<slot>`よりも上部に浮上します。
 The full path to the original event target, with all the shadow elements, can be obtained using `event.composedPath()`. As we can see from the name of the method, that path is taken after the composition.
+全てのシャドウ要素と共に、オリジナルのイベントターゲットへのフルパスは、`event.composedPath()`を使用して取得されます。このメソッドの名前から分かる通り、そのパスは合成後に取得されます。
 
 In the example above, the flattened DOM is:
-
+上記の例では、フラット化されたDOMは:
 ```html
 <user-card id="userCard">
   #shadow-root
@@ -95,11 +96,13 @@ In the example above, the flattened DOM is:
 
 
 So, for a click on `<span slot="username">`, a call to `event.composedPath()` returns an array: [`span`, `slot`, `div`, `shadow-root`, `user-card`, `body`, `html`, `document`, `window`]. That's exactly the parent chain from the target element in the flattened DOM, after the composition.
+なので、`<span slot="username">`のクリックで、`event.composedPath()`のコールは配列[`span`, `slot`, `div`, `shadow-root`, `user-card`, `body`, `html`, `document`, `window`]を返します。これがまさに合成後のフラット化DOM内でのターゲット要素から親チェーンのことです。
 
 ```warn header="Shadow tree details are only provided for `{mode:'open'}` trees"
 If the shadow tree was created with `{mode: 'closed'}`, then the composed path starts from the host: `user-card` and upwards.
-
+Shadow ツリーが`{mode: 'closed'}`と作られた場合、その合成パスはホスト: `user-card`とその上部から始まります。
 That's the similar principle as for other methods that work with shadow DOM. Internals of closed trees are completely hidden.
+これはshadow DOMと作用する他のメソッドと同様の原理です。閉じた木の内部は完全に隠されています。
 ```
 
 


### PR DESCRIPTION
以下に新出のキーワードの中でも頻出のものを参照元と共に一覧で掲載いたします。
EN: shadow host -> JP: Shadow ホスト
https://developers.google.com/web/fundamentals/web-components/shadowdom

EN: shadow element -> JP: shadow要素
https://developer.mozilla.org/ja/docs/Web/HTML/Element/Shadow

bubbling -> バブリング
https://developer.mozilla.org/ja/docs/Web/API/Event/bubbles

よろしくお願いいたします。