### PR TITLE
Fix 1-js/06/08/article

### DIFF
--- a/1-js/06-advanced-functions/08-settimeout-setinterval/article.md
+++ b/1-js/06-advanced-functions/08-settimeout-setinterval/article.md
@@ -218,7 +218,7 @@ setTimeout(function run() {
 
 ![](settimeout-interval.svg)
 
-**再帰的な `setInterval` は固定の遅延 (ここでは 100ms) を保証します。**
+**再帰的な `setTimeout` は固定の遅延 (ここでは 100ms) を保証します。**
 
 新しい呼び出しは、以前の呼び出しの終わりに計画されるためです。
 


### PR DESCRIPTION
「[スケジューリング: setTimeout と setInterval](https://ja.javascript.info/settimeout-setinterval)」 内の 「[再帰的な（ネストされた） setTimeout](https://ja.javascript.info/settimeout-setinterval#ref-1193)」 で setTimeout の説明ですが関数名が `setInterval` になっていたため修正しました。